### PR TITLE
Fixed install.json so shared drive works with default comfyui install

### DIFF
--- a/install.json
+++ b/install.json
@@ -12,60 +12,67 @@
       "cpu": "pip install torch==2.3.1 torchvision==0.18.1 torchaudio==2.3.1 --index-url https://download.pytorch.org/whl/cpu"
     }
   },
-  "run": [{
-    "method": "shell.run",
-    "params": {
-      "message": "git clone https://github.com/lllyasviel/Fooocus app"
-    }
-  }, {
-    "method": "shell.run",
-    "params": {
-      "venv": "env",
-      "path": "app",
-      "message": [
-        "{{(platform === 'darwin' ? self.cmds.darwin : (['nvidia', 'amd'].includes(gpu) ? self.cmds[platform][gpu] : self.cmds[platform].cpu))}}",
-        "pip install -r requirements_versions.txt"
-      ]
-    }
-  }, {
-    "method": "fs.share",
-    "params": {
-      "drive": {
-        "checkpoints": "app/models/checkpoints",
-        "clip": "app/models/clip",
-        "clip_vision": "app/models/clip_vision",
-        "configs": "app/models/configs",
-        "controlnet": "app/models/controlnet",
-        "diffusers": "app/models/diffusers",
-        "embeddings": "app/models/embeddings",
-        "gligen": "app/models/gligen",
-        "hypernetworks": "app/models/hypernetworks",
-        "inpaint": "app/models/inpaint",
-        "loras": "app/models/loras",
-        "prompt_expansion": "app/models/prompt_expansion",
-        "style_models": "app/models/style_models",
-        "unet": "app/models/unet",
-        "upscale_models": "app/models/upscale_models",
-        "vae": "app/models/vae",
-        "vae_approx": "app/models/vae_approx"
-      },
-      "peers": [
-        "https://github.com/cocktailpeanutlabs/automatic1111.git",
-        "https://github.com/cocktailpeanutlabs/comfyui.git",
-        "https://github.com/cocktailpeanutlabs/forge.git"
-      ]
-    }
-  }, {
-    "method": "fs.share",
-    "params": {
-      "drive": {
-        "outputs": "app/outputs"
+  "run": [
+    {
+      "method": "shell.run",
+      "params": {
+        "message": "git clone https://github.com/lllyasviel/Fooocus app"
+      }
+    },
+    {
+      "method": "shell.run",
+      "params": {
+        "venv": "env",
+        "path": "app",
+        "message": [
+          "{{(platform === 'darwin' ? self.cmds.darwin : (['nvidia', 'amd'].includes(gpu) ? self.cmds[platform][gpu] : self.cmds[platform].cpu))}}",
+          "pip install -r requirements_versions.txt"
+        ]
+      }
+    },
+    {
+      "method": "fs.share",
+      "params": {
+        "drive": {
+          "checkpoints": "app/models/checkpoints",
+          "clip": "app/models/clip",
+          "clip_vision": "app/models/clip_vision",
+          "configs": "app/models/configs",
+          "controlnet": "app/models/controlnet",
+          "diffusers": "app/models/diffusers",
+          "embeddings": "app/models/embeddings",
+          "gligen": "app/models/gligen",
+          "hypernetworks": "app/models/hypernetworks",
+          "inpaint": "app/models/inpaint",
+          "loras": "app/models/loras",
+          "prompt_expansion": "app/models/prompt_expansion",
+          "style_models": "app/models/style_models",
+          "unet": "app/models/unet",
+          "upscale_models": "app/models/upscale_models",
+          "vae": "app/models/vae",
+          "vae_approx": "app/models/vae_approx"
+        },
+        "peers": [
+          "https://github.com/pinokiofactory/comfy.git",
+          "https://github.com/cocktailpeanutlabs/automatic1111.git",
+          "https://github.com/cocktailpeanutlabs/comfyui.git",
+          "https://github.com/cocktailpeanutlabs/forge.git"
+        ]
+      }
+    },
+    {
+      "method": "fs.share",
+      "params": {
+        "drive": {
+          "outputs": "app/outputs"
+        }
+      }
+    },
+    {
+      "method": "notify",
+      "params": {
+        "html": "App launched. Click 'start' to get started"
       }
     }
-  }, {
-    "method": "notify",
-    "params": {
-      "html": "App launched. Click 'start' to get started"
-    }
-  }]
+  ]
 }


### PR DESCRIPTION
Currently the default comfyui install via pinokio is at `https://github.com/pinokiofactory/comfy.git`. This must have been changed at some point from `https://github.com/cocktailpeanutlabs/comfyui.git` and as a result it creates a new shared drive rather than linking the it should. I was able to fix this by adding the peer connection to the former and it seems to now work properly. 